### PR TITLE
Fix the deploy enum

### DIFF
--- a/MANIFEST/MANIFEST-v1.0.0.schema.json
+++ b/MANIFEST/MANIFEST-v1.0.0.schema.json
@@ -164,7 +164,7 @@
                 "method": {
                     "description": "The method of deployment",
                     "type": "string",
-                    "enum": [ "typhon", "travis", "concourse", "jenkins", "digital-ocean" ]
+                    "enum": [ "fabric", "travis", "concourse", "jenkins" ]
                 },
                 "target": {
                     "description": "The target platform for deployment",


### PR DESCRIPTION
## Description

`digital-ocean` & `typhon` are  not a ways to deploy an application and `fabric` was missing.